### PR TITLE
Improve installability - added entrypoints for scripts

### DIFF
--- a/globalise_tools/__init__.py
+++ b/globalise_tools/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '0.1.0'
+__version__ = '0.2.0'
 
 from .tools import (
     PXTextRegion,

--- a/globalise_tools/tools.py
+++ b/globalise_tools/tools.py
@@ -75,8 +75,8 @@ class Annotation:
     type: str
     id: str
     page_id: str
-    physical_span: TextSpan = TextSpan()
-    logical_span: TextSpan = TextSpan()
+    physical_span: TextSpan = field(default_factory=TextSpan, hash=False)
+    logical_span: TextSpan = field(default_factory=TextSpan, hash=False) 
     # offset: int
     # length: int
     # physical_segmented_version_id: str = ""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,10 +1,13 @@
 [tool.poetry]
 name = "globalise-tools"
-version = "0.1.1"
+version = "0.2.0"
 description = ""
 authors = ["Bram Buitendijk <bram.buitendijk@di.huc.knaw.nl>", "Maarten van Gompel <proycon@anaproy.nl>"]
 readme = "README.md"
-packages = [{ include = "globalise_tools" }]
+packages = [
+    { include = "globalise_tools" },
+    { include = "scripts", to="globalise_tools" },
+]
 
 [tool.poetry.dependencies]
 annorepo-client = "^0.1.3"
@@ -38,6 +41,11 @@ pagexml-tools = { path = "/Users/bram/workspaces/pagexml", develop = true }
 provenance-client = { path = "/Users/bram/workspaces/provenance/provenance-python-client", develop = true }
 spacy = { extras = ["apple"], version = "^3.4.3" }
 textrepo-client = { path = "/Users/bram/workspaces/textrepo/textrepo-client-python", develop = true }
+
+[tool.poetry.scripts]
+gt-classify-language = "globalise_tools.scripts.gt_classify_language:main"
+gt-extract-lines = "globalise_tools.scripts.gt_extract_lines:main"
+
 
 [build-system]
 requires = ["poetry-core"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 name = "globalise-tools"
 version = "0.1.1"
 description = ""
-authors = ["Bram Buitendijk <bram.buitendijk@di.huc.knaw.nl>"]
+authors = ["Bram Buitendijk <bram.buitendijk@di.huc.knaw.nl>", "Maarten van Gompel <proycon@anaproy.nl>"]
 readme = "README.md"
 packages = [{ include = "globalise_tools" }]
 

--- a/scripts/gt_classify_language.py
+++ b/scripts/gt_classify_language.py
@@ -87,9 +87,7 @@ def print_langs(inv_nr, page_no, textregion_id, textregion_type, line_id, page_l
             print("\t0",end="")
     print()
 
-
-
-if __name__ == '__main__':
+def main():
     parser = ArgumentParser(
         description="Extract line text from pagexml files",
         formatter_class=ArgumentDefaultsHelpFormatter)
@@ -143,5 +141,9 @@ if __name__ == '__main__':
                         page_langs.append(lang)
                 if inv_nr:
                     print_langs(inv_nr, page_no,textregion_id, textregion_type, "",region_langs,"")
+
+
+if __name__ == '__main__':
+    main()
 
 

--- a/scripts/gt_extract_lines.py
+++ b/scripts/gt_extract_lines.py
@@ -7,8 +7,12 @@ from argparse import ArgumentParser, ArgumentDefaultsHelpFormatter
 import pagexml.parser as px
 from loguru import logger
 
+def main():
+    args = get_arguments()
+    run(args.input_directory, args.output_directory)
+
 @logger.catch
-def main(base_pagexml_path: str, output_directory: str):
+def run(base_pagexml_path: str, output_directory: str):
     inv_nrs = sorted(
         [p.split("/")[-1] for p in glob.glob(f"{base_pagexml_path}/*") if os.path.isdir(p)])
     for i in inv_nrs:
@@ -53,5 +57,4 @@ def get_arguments():
 
 
 if __name__ == '__main__':
-    args = get_arguments()
-    main(args.input_directory, args.output_directory)
+    main()


### PR DESCRIPTION
I included the scripts in the globalize_tools package and added entrypoints for them, so they can be properly installed and do not need to be run manually from the scripts/ directory.  I needed to rename hyphens to underscores for this to work btw.

I also fixed an import error regarding dataclasses and bumped the version number. 

I spoke with @kintopp on making the pipeline properly reproducible, which implies things should be installable, version pinned, etc.. This is a step in that direction. I'd suggest we to this for all scripts and do a formal release at some point?